### PR TITLE
Add error handling to forgotten-sender

### DIFF
--- a/forgotten-sender/listing-02/main.go
+++ b/forgotten-sender/listing-02/main.go
@@ -4,23 +4,31 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"time"
 )
 
 func main() {
-	process("gophers")
+	if err := process("gophers"); err != nil {
+		log.Print(err)
+	}
 }
 
 // process is the work for the program. It finds a record
 // then prints it.
-func process(term string) {
-	result := search(term)
-	fmt.Println("Received:", result)
+func process(term string) error {
+	record, err := search(term)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Received:", record)
+	return nil
 }
 
-// search simulates a function that finds a document based
+// search simulates a function that finds a record based
 // on a search term. It takes 200ms to perform this work.
-func search(term string) string {
+func search(term string) (string, error) {
 	time.Sleep(200 * time.Millisecond)
-	return "some value"
+	return "some value", nil
 }

--- a/forgotten-sender/listing-03-leak/main.go
+++ b/forgotten-sender/listing-03-leak/main.go
@@ -56,8 +56,7 @@ func process(term string) error {
 	// Launch a goroutine to find the record. Send the return
 	// value on the channel.
 	go func() {
-		record, err := search(term)
-		ch <- result{record: record, err: err}
+		ch <- search(term)
 	}()
 
 	// Block waiting to receive from the goroutine's channel
@@ -76,7 +75,10 @@ func process(term string) error {
 
 // search simulates a function that finds a record based
 // on a search term. It takes 200ms to perform this work.
-func search(term string) (string, error) {
+func search(term string) result {
 	time.Sleep(200 * time.Millisecond)
-	return "some value", nil
+	return result{
+		record: "some value",
+		err:    nil,
+	}
 }

--- a/forgotten-sender/listing-03-leak/main.go
+++ b/forgotten-sender/listing-03-leak/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"runtime"
@@ -16,7 +17,9 @@ func main() {
 	// Capture starting number of goroutines.
 	startingGs := runtime.NumGoroutine()
 
-	process("gophers")
+	if err := process("gophers"); err != nil {
+		log.Print(err)
+	}
 
 	// Hold the program from terminating for 1 second to see
 	// if any goroutines created by process terminate.
@@ -32,36 +35,48 @@ func main() {
 	fmt.Println("Number of goroutines leaked:", endingGs-startingGs)
 }
 
+// result wraps the return values from search. It allows us
+// to pass both values across a single channel.
+type result struct {
+	record string
+	err    error
+}
+
 // process is the work for the program. It finds a record
 // then prints it. It fails if it takes more than 100ms.
-func process(term string) {
+func process(term string) error {
 
 	// Create a context that will be canceled in 100ms.
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
 	// Make a channel for the goroutine to report its result.
-	ch := make(chan string)
+	ch := make(chan result)
 
 	// Launch a goroutine to find the record. Send the return
 	// value on the channel.
 	go func() {
-		ch <- search(term)
+		record, err := search(term)
+		ch <- result{record: record, err: err}
 	}()
 
 	// Block waiting to receive from the goroutine's channel
 	// or for the context to be canceled.
 	select {
-	case result := <-ch:
-		fmt.Println("Received:", result)
 	case <-ctx.Done():
-		log.Println("search canceled")
+		return errors.New("search canceled")
+	case result := <-ch:
+		if result.err != nil {
+			return result.err
+		}
+		fmt.Println("Received:", result.record)
+		return nil
 	}
 }
 
-// search simulates a function that finds a document based
+// search simulates a function that finds a record based
 // on a search term. It takes 200ms to perform this work.
-func search(term string) string {
+func search(term string) (string, error) {
 	time.Sleep(200 * time.Millisecond)
-	return "some value"
+	return "some value", nil
 }

--- a/forgotten-sender/listing-04-fix/main.go
+++ b/forgotten-sender/listing-04-fix/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"runtime"
@@ -16,7 +17,9 @@ func main() {
 	// Capture starting number of goroutines.
 	startingGs := runtime.NumGoroutine()
 
-	process("gophers")
+	if err := process("gophers"); err != nil {
+		log.Print(err)
+	}
 
 	// Hold the program from terminating for 1 second to see
 	// if any goroutines created by process terminate.
@@ -32,9 +35,16 @@ func main() {
 	fmt.Println("Number of goroutines leaked:", endingGs-startingGs)
 }
 
+// result wraps the return values from search. It allows us
+// to pass both values across a single channel.
+type result struct {
+	record string
+	err    error
+}
+
 // process is the work for the program. It finds a record
 // then prints it. It fails if it takes more than 100ms.
-func process(term string) {
+func process(term string) error {
 
 	// Create a context that will be canceled in 100ms.
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
@@ -42,27 +52,32 @@ func process(term string) {
 
 	// Make a channel for the goroutine to report its result.
 	// Give it capacity so the sender won't block.
-	ch := make(chan string, 1)
+	ch := make(chan result, 1)
 
 	// Launch a goroutine to find the record. Send the return
 	// value on the channel.
 	go func() {
-		ch <- search(term)
+		record, err := search(term)
+		ch <- result{record: record, err: err}
 	}()
 
 	// Block waiting to receive from the goroutine's channel
 	// or for the context to be canceled.
 	select {
-	case result := <-ch:
-		fmt.Println("Received:", result)
 	case <-ctx.Done():
-		log.Println("search canceled")
+		return errors.New("search canceled")
+	case result := <-ch:
+		if result.err != nil {
+			return result.err
+		}
+		fmt.Println("Received:", result.record)
+		return nil
 	}
 }
 
-// search simulates a function that finds a document based
+// search simulates a function that finds a record based
 // on a search term. It takes 200ms to perform this work.
-func search(term string) string {
+func search(term string) (string, error) {
 	time.Sleep(200 * time.Millisecond)
-	return "some value"
+	return "some value", nil
 }

--- a/forgotten-sender/listing-04-fix/main.go
+++ b/forgotten-sender/listing-04-fix/main.go
@@ -57,8 +57,7 @@ func process(term string) error {
 	// Launch a goroutine to find the record. Send the return
 	// value on the channel.
 	go func() {
-		record, err := search(term)
-		ch <- result{record: record, err: err}
+		ch <- search(term)
 	}()
 
 	// Block waiting to receive from the goroutine's channel
@@ -77,7 +76,10 @@ func process(term string) error {
 
 // search simulates a function that finds a record based
 // on a search term. It takes 200ms to perform this work.
-func search(term string) (string, error) {
+func search(term string) result {
 	time.Sleep(200 * time.Millisecond)
-	return "some value", nil
+	return result{
+		record: "some value",
+		err:    nil,
+	}
 }


### PR DESCRIPTION
The "Forgotten Senders" leak example is based around a function 
```go
func search(term string) string
```
which is supposed to simulate an operation like a DB lookup or an HTTP call that might take a long time. Our code shows how you could wrap that thing in a goroutine to abort early if it takes too long.

If this was really a DB lookup or HTTP call it would have the possibility of failure which means the signature should be 

```go
func search(term string) (string, error)
```

This complicates the code quite a bit, as you can see from this PR's diff. I am trying to decide if this complexity is worth adding.

1. Pro: It's more realistic. If you are looking for a pattern of how to wrap something in a time-sensitive way you would need to handle that error.
2. Con: It makes the post more complicated and does not affect my primary goal which is teaching how to detect the leak introduced by receiving from a channel with a timeout.